### PR TITLE
Drop memoization

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "isbt",
     "test": "yarn workspaces run jest",
     "bump": "lerna version --exact --conventional-commits --no-push",
-    "publish": "lerna exec 'npm publish --registry https://registry.npmjs.org'"
+    "publish": "lerna exec --since main 'npm publish --access public --registry https://registry.npmjs.org'"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.0.0",

--- a/packages/chain-error/src/ChainError.ts
+++ b/packages/chain-error/src/ChainError.ts
@@ -41,7 +41,7 @@ export class ChainError extends Error {
 
     super(message)
 
-    // for `isChainableError` helper
+    // for `isChainError` helper
     Object.defineProperty(this, '_tag', {
       value: 'ChainError',
       enumerable: false,

--- a/packages/chain-error/test/ChainError.test.ts
+++ b/packages/chain-error/test/ChainError.test.ts
@@ -49,25 +49,9 @@ describe('ChainError', () => {
       error = e
     }
 
-    expect(error?.stack).toContain('Caused by: Error: chain1')
-    expect(error?.stack).toContain('Caused by: Error: Original Error')
-  })
+    const stack = error?.stack;
 
-  it('memoize error stack', async () => {
-    const promise = chain2()
-
-    let error: Error | null = null
-    try {
-      await flush(promise)
-    } catch (e) {
-      error = e
-    }
-
-    const causeSpy = jest.spyOn(error as ChainError, 'cause', 'get')
-
-    void error?.stack
-    void error?.stack
-
-    expect(causeSpy).toHaveBeenCalledTimes(1)
+    expect(stack).toContain('Caused by: Error: chain1')
+    expect(stack).toContain('Caused by: Error: Original Error')
   })
 })


### PR DESCRIPTION
Most applications will have to calculate long error stack in a specific error handling location and then report / log it. 
By doing so we also avoid duplication of the stacks across the entire chain.

Currently there's no significant indication that memoization by default will improve something.    